### PR TITLE
Word filter hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +206,15 @@ name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -494,6 +509,7 @@ dependencies = [
  "colored",
  "dirs",
  "env_logger",
+ "itertools",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ chrono = { version = "0.4.11", features = ["serde"] }
 colored = "2"
 dirs = "3.0.1"
 env_logger = "0.8.1"
+itertools = "0.9.0"
 log = "0.4.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ use crate::{
   task::{Status, Task, TaskManager, UID},
   term::Term,
 };
+use itertools::Itertools;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -130,12 +131,12 @@ pub fn list_tasks(
   Metadata::validate(&metadata)?;
 
   if !metadata.is_empty() {
-    print!("{} {}", "[".bright_black(), metadata[0].filter_like());
-
-    for md in &metadata[1..] {
-      print!(", {}", md.filter_like());
-    }
-    println!("{}", " ]".bright_black());
+    print!(
+      "{} {} {}",
+      "[".bright_black(),
+      metadata.iter().map(Metadata::filter_like).format(", "),
+      "]".bright_black()
+    );
   }
 
   let name_filter = if name.is_empty() {
@@ -143,6 +144,19 @@ pub fn list_tasks(
   } else {
     name.split_ascii_whitespace().collect()
   };
+
+  if !name_filter.is_empty() {
+    println!(
+      "{}{} {}: {} {}",
+      if !metadata.is_empty() { " " } else { "" },
+      "[".bright_black(),
+      "contains".italic(),
+      name_filter.iter().format(", "),
+      "]".bright_black()
+    );
+  } else {
+    println!();
+  }
 
   let task_mgr = TaskManager::new_from_config(config)?;
   let mut tasks: Vec<_> = task_mgr


### PR DESCRIPTION
Can possibly be merged after #54

I decided to put word filter hint on the same line after the metadata filter.
Using itertools allows to just use one print! for the output. What is your opinion on the readability?

```
Running `target/debug/td -c ./intg-tests ls --all does this work '@X' '#a' '#b' +c`

[ @X, #a, #b, +Critical ] [ contains: this, does, work ]
```