### PR TITLE
Display tags column

### DIFF
--- a/intg-tests/config.toml
+++ b/intg-tests/config.toml
@@ -9,6 +9,7 @@ age_col_name = 'Age'
 spent_col_name = 'Spent'
 prio_col_name = 'Prio'
 project_col_name = 'Project'
+tags_col_name = 'Tags'
 status_col_name = 'Status'
 description_col_name = 'Description'
 display_empty_cols = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -710,7 +710,7 @@ impl DisplayOptions {
       }
 
       // compute tags width if any
-      if self.has_tags {
+      if config.display_tags_listings() && self.has_tags {
         tags_width = self.tags_width + 1; // FIXME
       } else {
         tags_width = 0;
@@ -786,7 +786,7 @@ fn display_task_header(config: &Config, opts: &DisplayOptions) {
     );
   }
 
-  if display_empty_cols || opts.has_tags {
+  if config.display_tags_listings() && (display_empty_cols || opts.has_tags) {
     print!(
       " {tags:<tags_width$}",
       tags = config.tags_col_name().underline(),
@@ -861,7 +861,7 @@ fn display_task_inline(config: &Config, uid: UID, task: &Task, opts: &DisplayOpt
     );
   }
 
-  if display_empty_cols || opts.has_tags {
+  if config.display_tags_listings() && (display_empty_cols || opts.has_tags) {
     display_tags(task, opts);
   }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -472,12 +472,16 @@ struct DisplayOptions {
   description_width: usize,
   /// Width of the task project column.
   project_width: usize,
+  /// Width of the task tags column.
+  tags_width: usize,
   /// Whether any task has spent time.
   has_spent_time: bool,
   /// Whether we have a priority in at least one task.
   has_priorities: bool,
   /// Whether we have a project in at least one task.
   has_projects: bool,
+  /// Whether we have a tag in at least one task.
+  has_tags: bool,
   /// Offset to use for the description column.
   description_offset: usize,
   /// Maximum columns to fit in the description column.
@@ -508,9 +512,10 @@ impl DisplayOptions {
       has_spent_time,
       has_priorities,
       has_projects,
+      has_tags,
       notes_nb_width,
     ) = tasks.into_iter().fold(
-      (0, 0, 0, 0, 0, 0, false, false, false, 0),
+      (0, 0, 0, 0, 0, 0, false, false, false, false, 0),
       |(
         task_uid_width,
         age_width,
@@ -521,6 +526,7 @@ impl DisplayOptions {
         has_spent_time,
         has_priorities,
         has_projects,
+        has_tags,
         notes_nb_width,
       ),
        (uid, task)| {
@@ -533,6 +539,7 @@ impl DisplayOptions {
         let has_spent_time = has_spent_time || task.spent_time() != Duration::zero();
         let has_priorities = has_priorities || task.priority().is_some();
         let has_projects = has_projects || task.project().is_some();
+        let has_tags = has_tags || task.tags().next().is_some();
         let notes_nb_width = notes_nb_width.max(Self::guess_notes_width(
           task.notes().iter().map(|note| note.content.as_str()),
         ));
@@ -547,6 +554,7 @@ impl DisplayOptions {
           has_spent_time,
           has_priorities,
           has_projects,
+          has_tags,
           notes_nb_width,
         )
       },
@@ -559,9 +567,11 @@ impl DisplayOptions {
       status_width: status_width.max(config.status_col_name().width()),
       description_width: description_width.max(config.description_col_name().width()),
       project_width: project_width.max(config.project_col_name().width()),
+      tags_width: project_width.max(config.tags_col_name().width()),
       has_spent_time,
       has_priorities,
       has_projects,
+      has_tags,
       description_offset: 0,
       max_description_cols: None,
       notes_nb_width,
@@ -750,6 +760,14 @@ fn display_task_header(config: &Config, opts: &DisplayOptions) {
       " {project:<project_width$}",
       project = config.project_col_name().underline(),
       project_width = opts.project_width,
+    );
+  }
+
+  if display_empty_cols || opts.has_tags {
+    print!(
+      " {tags:<tags_width$}",
+      tags = config.tags_col_name().underline(),
+      tags_width = opts.tags_width,
     );
   }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 //! Command line interface.
 
 use chrono::{DateTime, Duration, Utc};
-use colored::Colorize;
-use itertools::Itertools;
+use colored::Colorize as _;
+use itertools::Itertools as _;
 use std::{cmp::Reverse, error::Error, fmt::Display, iter::once, path::PathBuf};
 use structopt::StructOpt;
 use unicode_width::UnicodeWidthStr;
@@ -888,7 +888,7 @@ fn display_task_inline(config: &Config, uid: UID, task: &Task, opts: &DisplayOpt
 fn display_tags(task: &Task, opts: &DisplayOptions) {
   print!(
     " {tags:<tags_width$}",
-    tags = task.tags().intersperse(", ").collect::<String>(),
+    tags = task.tags().intersperse(", ").collect::<String>().yellow(),
     tags_width = opts.tags_width,
   );
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,9 @@ pub struct MainConfig {
   /// "Number of notes” column name."
   notes_nb_col_name: String,
 
+  /// Display tags in listings.
+  display_tags_listings: bool,
+
   /// Editor to use for interactive editing.
   ///
   /// If absent, default to `$EDITOR`. If neither the configuration or `$EDITOR` is set,
@@ -98,6 +101,7 @@ impl Default for MainConfig {
       display_empty_cols: false,
       max_description_lines: 2,
       notes_nb_col_name: "Notes".to_owned(),
+      display_tags_listings: true,
       interactive_editor: None,
     }
   }
@@ -121,7 +125,8 @@ impl MainConfig {
     description_col_name: impl Into<String>,
     display_empty_cols: bool,
     max_description_lines: usize,
-    notes_nb_col_name: String,
+    notes_nb_col_name: impl Into<String>,
+    display_tags_listings: bool,
     interactive_editor: impl Into<Option<String>>,
   ) -> Self {
     Self {
@@ -140,7 +145,8 @@ impl MainConfig {
       description_col_name: description_col_name.into(),
       display_empty_cols,
       max_description_lines,
-      notes_nb_col_name,
+      notes_nb_col_name: notes_nb_col_name.into(),
+      display_tags_listings,
       interactive_editor: interactive_editor.into(),
     }
   }
@@ -243,6 +249,10 @@ impl Config {
 
   pub fn notes_nb_col_name(&self) -> &str {
     &self.main.notes_nb_col_name
+  }
+
+  pub fn display_tags_listings(&self) -> bool {
+    self.main.display_tags_listings
   }
 
   pub fn interactive_editor(&self) -> Option<&str> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,9 @@ pub struct MainConfig {
   /// “Project” column name.
   project_col_name: String,
 
+  /// “Tags” column name.
+  tags_col_name: String,
+
   /// “Status” column name.
   status_col_name: String,
 
@@ -89,6 +92,7 @@ impl Default for MainConfig {
       spent_col_name: "Spent".to_owned(),
       prio_col_name: "Prio".to_owned(),
       project_col_name: "Project".to_owned(),
+      tags_col_name: "Tags".to_owned(),
       status_col_name: "Status".to_owned(),
       description_col_name: "Description".to_owned(),
       display_empty_cols: false,
@@ -112,6 +116,7 @@ impl MainConfig {
     spent_col_name: impl Into<String>,
     prio_col_name: impl Into<String>,
     project_col_name: impl Into<String>,
+    tags_col_name: impl Into<String>,
     status_col_name: impl Into<String>,
     description_col_name: impl Into<String>,
     display_empty_cols: bool,
@@ -130,6 +135,7 @@ impl MainConfig {
       spent_col_name: spent_col_name.into(),
       prio_col_name: prio_col_name.into(),
       project_col_name: project_col_name.into(),
+      tags_col_name: tags_col_name.into(),
       status_col_name: status_col_name.into(),
       description_col_name: description_col_name.into(),
       display_empty_cols,
@@ -213,6 +219,10 @@ impl Config {
 
   pub fn project_col_name(&self) -> &str {
     &self.main.project_col_name
+  }
+
+  pub fn tags_col_name(&self) -> &str {
+    &self.main.tags_col_name
   }
 
   pub fn status_col_name(&self) -> &str {


### PR DESCRIPTION
Implements #38 

This just reserves enough space to display all tag values which may not work when there are a lot of tags.
In a previous commit a had a simple logic to just display ... after the end of the space was reached but I'm not sure if that is the right approach?