### PR TITLE
Add history view

### DIFF
--- a/src/subcmd.rs
+++ b/src/subcmd.rs
@@ -1,6 +1,6 @@
 use crate::{
   cli::NoteCommand,
-  cli::{add_task, edit_task, list_tasks, show_task, SubCommand},
+  cli::{add_task, edit_task, list_tasks, show_task, show_task_history, SubCommand},
   config::Config,
   interactive_editor::interactively_edit,
   task::{Status, TaskManager, UID},
@@ -167,6 +167,14 @@ pub fn run_subcmd(
               "{}",
               "missing or unknown task to add, edit or list notes about".red()
             );
+          }
+        }
+
+        SubCommand::History => {
+          if let Some((uid, task)) = task {
+            show_task_history(&config, uid, task);
+          } else {
+            println!("{}", "missing or unknown task to display history".red());
           }
         }
       }

--- a/src/task.rs
+++ b/src/task.rs
@@ -218,6 +218,11 @@ impl Task {
     notes
   }
 
+  /// Iterate over the whole history, if any.
+  pub fn history(&self) -> impl Iterator<Item = &Event> {
+    self.history.iter()
+  }
+
   /// Compute the time spent on this task.
   pub fn spent_time(&self) -> Duration {
     let (spent, last_wip) =


### PR DESCRIPTION
I tried implementing #11 without knowing how it should look like so please try it locally :smile: 

Checklist before merge:

- [ ] Update documentation of the history feature in the rfc?
- [ ] Add aliases for the history command (maybe)
- [ ] Formatting of the options is ok
- [ ] Text for each event is ok

Example output
```
Tue, 13 Oct 2020 at 19:04: Task created with uid 3
Tue, 13 Oct 2020 at 19:04: Status changed to TODO
Tue, 13 Oct 2020 at 19:04: Project set to super-cool-project
Tue, 13 Oct 2020 at 19:04: Tag added #tag0
Tue, 13 Oct 2020 at 19:04: Tag added #i-love-dogs
Tue, 13 Oct 2020 at 19:04: Priority set to HIGH
Tue, 13 Oct 2020 at 19:06: Note added This is the first note. This is a test. Be advised.
Tue, 13 Oct 2020 at 19:10: Note added I’d like to discuss about my previous note. This is not a test. I repeat: this is not a test.
```
