### PR TITLE
Doesn’t panic when the terminal doesn’t expose its dimensions.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -498,7 +498,17 @@ impl DisplayOptions {
     };
 
     opts.description_offset = opts.guess_description_col_offset(config);
-    opts.max_description_cols = term.dimensions().unwrap()[0].checked_sub(opts.description_offset);
+
+    if let Some(term_dims) = term.dimensions() {
+      opts.max_description_cols = term_dims[0].checked_sub(opts.description_offset);
+    } else {
+      println!(
+        "{}",
+        "⚠ You’re using a terminal that doesn’t expose its dimensions; expect broken output ⚠"
+          .yellow()
+          .bold()
+      );
+    }
 
     opts
   }


### PR DESCRIPTION
We display a warning message for such cases.

_In `kitty`_:
![Screenshot from 2021-01-15 17-48-02](https://user-images.githubusercontent.com/506592/104754879-06577480-575a-11eb-9141-97ed5786e9ea.png)

_In `eshell`_:
![Screenshot from 2021-01-15 17-48-11](https://user-images.githubusercontent.com/506592/104754878-05bede00-575a-11eb-9022-b3635163d75c.png)
